### PR TITLE
Fix spacing between company names in the index footer

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -187,11 +187,11 @@ $ irmin get foo/bar`}
               </a>
             </p>
             <p>
-              Irmin is part of the <a href="https://mirage.io">MirageOS</a>
-              project and supported by
-              <a href="https://tarides.com">Tarides</a>
-              and <a href="https://robur.io">Robur</a>
-              and <a href="https://ocamllabs.io">OCaml Labs</a>.
+              Irmin is part of the <a href="https://mirage.io">MirageOS</a>{" "}
+              project and is supported by{" "}
+              <a href="https://tarides.com">Tarides</a>,{" "}
+              <a href="https://robur.io">Robur</a> and{" "}
+              <a href="https://ocamllabs.io">OCaml Labs</a>.
             </p>
           </section>
         </div>


### PR DESCRIPTION
See https://github.com/mirage/irmin.org/pull/34#issuecomment-557138871.