### PR TITLE
Add OCaml-CI status badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# Irmin website &nbsp;&nbsp; [![Travis status][travis-img]][travis]
+# Irmin website &nbsp;&nbsp; [[OCaml-CI status][ocaml-ci-img][ocaml-ci] [![Travis status][travis-img]][travis]
 
+[ocaml-ci]: https://ci.ocamllabs.io/github/mirage/alcotest
+[ocaml-ci-img]: https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Fmirage%2Firmin.org%2Fmaster&logo=ocaml
 [travis]: https://travis-ci.org/mirage/irmin.org/branches
 [travis-img]: https://travis-ci.org/mirage/irmin.org.svg?branch=master
 


### PR DESCRIPTION
Now that https://github.com/ocurrent/ocaml-ci/pull/100 has been merged, we have access to new badges for OCaml-CI.