### PR TITLE
Fix tutorial path in gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,7 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        path: `${__dirname}/data/tutorial`,
+        path: `${__dirname}/data/tutorial/`,
         name: `tutorial`
       }
     },


### PR DESCRIPTION
This prevented `yarn run develop` from working (would display blank pages).