### PR TITLE
Add Irmin CI badge

### DIFF
--- a/src/components/home/homeHeader.css
+++ b/src/components/home/homeHeader.css
@@ -17,3 +17,8 @@
   margin-bottom: 30px;
   margin-top: 20px;
 }
+
+.home-header .build {
+  height: 50px;
+  display: inline-block;
+}

--- a/src/components/home/homeHeader.js
+++ b/src/components/home/homeHeader.js
@@ -14,6 +14,13 @@ const HomeHeader = ({ pages, currentLink }) => {
           <img className="logo" src={imgLogo} alt="Irmin logo" />
         </Link>
         <h1>A distributed database built on the same principles as Git</h1>
+        <a href="https://ci.ocamllabs.io/github/mirage/irmin" className="build">
+          <img
+            src="https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Fmirage%2Firmin%2Fmaster&logo=ocaml\&style=for-the-badge"
+            alt="OCaml-CI Status"
+          />
+        </a>
+        <br />
         <a href="https://github.com/mirage/irmin" className="button github">
           <img src={imgGithub} alt="GitHub" />
           GitHub


### PR DESCRIPTION
Implements https://github.com/mirage/irmin.org/pull/54#issuecomment-584813326.
There are still some bugs in OCaml-CI that occasionally cause unrelated failures so I don't know if we actually want that, but here it is in case we do.
The current output is:
![image](https://user-images.githubusercontent.com/17850176/74327249-1ae1fe80-4d8c-11ea-90de-4b38467fc58a.png)
