### PR TITLE
Updates for irmin 2.6.1

### DIFF
--- a/data/tutorial/01_introduction.md
+++ b/data/tutorial/01_introduction.md
@@ -16,8 +16,9 @@ with Git, Irmin can be used to interact with Git repositories directly from
 within your application.
 
 Take a moment to skim the [README][irmin-readme] to familiarize yourself with
-some of the concepts. Also, if you find that anything is missing or unclear in
-this tutorial then please file [an issue][irmin-issues]!
+some of the concepts. This tutorial should always be up to date with the latest
+opam release. If you find that anything is outdated, missing or unclear then
+please file [an issue][irmin-issues]!
 
 <!-- prettier-ignore-start -->
 [irmin]: https://github.com/mirage/irmin

--- a/data/tutorial/02_command-line.md
+++ b/data/tutorial/02_command-line.md
@@ -97,8 +97,8 @@ module R = Irmin_unix.Resolver
 
 let () =
   R.Contents.add "my-content-type" (module Irmin.Contents.String);
-  R.Store.add "my-store-type" (fun (module Contents) ->
-    R.Store.v (module Irmin_mem.KV(Contents))
+  R.Store.add "my-store-type" (R.Store.Fixed_hash (fun (module Contents) ->
+    R.Store.v (module Irmin_mem.KV(Contents)))
   );
   Cli.(run ~default commands)
 ```

--- a/data/tutorial/03_getting-started.md
+++ b/data/tutorial/03_getting-started.md
@@ -221,13 +221,14 @@ For example, using `Men_store_json_value` we can assign
 `{"x": 1, "y": 2, "z": 3}` to the key `a/b/c`:
 
 ```ocaml
+let contents_equal = Irmin.Type.(unstage (equal Mem_store_json_value.contents_t))
 let main =
     let module Store = Mem_store_json_value in
     Store.Repo.v config >>= Store.master >>= fun t ->
     let value = `O ["x", `Float 1.; "y", `Float 2.; "z", `Float 3.] in
     Store.set_exn t ["a"; "b"; "c"] value ~info:(info "set a/b/c") >>= fun () ->
     Store.get t ["a"; "b"; "c"] >|= fun x ->
-    assert (Irmin.Type.equal Store.contents_t value x)
+    assert (contents_equal value x)
 let () = Lwt_main.run main
 ```
 
@@ -251,11 +252,11 @@ let main =
     let value = `O ["test", `O ["foo", `String "bar"]; "x", `Float 1.; "y", `Float 2.; "z", `Float 3.] in
     Proj.set t ["a"; "b"; "c"] value ~info:(info "set a/b/c") >>= fun () ->
     Store.get t ["a"; "b"; "c"; "x"] >>= fun x ->
-    assert (Irmin.Type.equal Store.contents_t (`Float 1.) x);
+    assert (contents_equal (`Float 1.) x);
     Store.get t ["a"; "b"; "c"; "test"; "foo"] >>= fun x ->
-    assert (Irmin.Type.equal Store.contents_t (`String "bar") x);
+    assert (contents_equal (`String "bar") x);
     Proj.get t ["a"; "b"] >|= fun x ->
-    assert (Irmin.Type.equal Store.contents_t (`O ["c", value]) x)
+    assert (contents_equal (`O ["c", value]) x)
 let () = Lwt_main.run main
 ```
 

--- a/data/tutorial/04_contents.md
+++ b/data/tutorial/04_contents.md
@@ -252,7 +252,7 @@ the newest value based on the attached timestamp.
     let merge ~old:_ (a, timestamp_a) (b, timestamp_b) =
         match Int64.compare timestamp_a timestamp_b with
         | 0 ->
-            if Irmin.Type.equal C.t a b then
+            if Irmin.Type.(unstage (equal C.t)) a b then
                 Irmin.Merge.ok (a, timestamp_a)
             else
                 let msg = "Conflicting entries have the same timestamp but different values" in

--- a/irmin-website.opam
+++ b/irmin-website.opam
@@ -8,10 +8,10 @@ bug-reports: "https://github.com/tarides/irmin.org/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.7.0"}
-  "irmin" {= "2.0.0" & with-test}
+  "irmin" {= "2.6.1" & with-test}
   "irmin-unix" {with-test}
-  "digestif" {= "0.7.3"}
-  "mdx" {>= "1.6.0"}
+  "digestif" {= "1.0.0"}
+  "mdx" {>= "1.8.1"}
   "lwt" {with-test}
   "hiredis" {with-test}
 ]


### PR DESCRIPTION
The redis implementation of `clear` is pretty bad, same with `test_and_set` - at some point I'd like to switch that example to use a `Hashtbl` or something simpler instead. For now, it should get the point across.