### PR TITLE
Fix link to String documentation.

### DIFF
--- a/data/tutorial/03_getting-started.md
+++ b/data/tutorial/03_getting-started.md
@@ -284,7 +284,7 @@ let () = Lwt_main.run main
 [irmin.s.tree]: https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Tree/index.html
 [irmin.type]: https://mirage.github.io/repr/repr/Repr/index.html
 [irmin.contents]: https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html
-[irmin.content.string]: https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-String
+[irmin.contents.string]: https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-String
 [irmin.private.conf]: https://mirage.github.io/irmin/irmin/Irmin/Private/Conf/index.html
 [irmin.repo]: https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Repo/index.html
 [irmin.repo.v]: https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Repo/index.html#val-v


### PR DESCRIPTION
Currently this shows up as a broken link.

<img width="933" alt="Screenshot 2023-12-03 at 12 45 43" src="https://github.com/mirage/irmin.org/assets/170937/6aebb72f-db0f-4b4a-87db-93ca27f16135">

Fixing the spelling of the name to `irmin.contents.string` addresses the problem.