### PR TITLE
Fix ocaml.ci.dev links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# Irmin website &nbsp;&nbsp; [![OCaml-CI status][ocaml-ci-img]][ocaml-ci] [![Travis status][travis-img]][travis]
+# Irmin website &nbsp;&nbsp; [![OCaml-CI status][ocaml-ci-img]][ocaml-ci]
 
-[ocaml-ci]: https://ci.ocamllabs.io/github/mirage/irmin.org
-[ocaml-ci-img]: https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Fmirage%2Firmin.org%2Fmaster&logo=ocaml
-[travis]: https://travis-ci.org/mirage/irmin.org/branches
-[travis-img]: https://travis-ci.org/mirage/irmin.org.svg?branch=master
+[ocaml-ci]: https://ocaml.ci.dev/github/mirage/irmin.org
+[ocaml-ci-img]: https://img.shields.io/endpoint?url=https%3A%2F%2Focaml.ci.dev%2Fbadge%2Fmirage%2Firmin.org%2Fmain&logo=ocaml
 
 This repository contains the source code for [irmin.org][irmin.org], which describes the [Irmin
 distributed database][irmin] and contains tutorials for getting started with Irmin.


### PR DESCRIPTION
Also removed travis.org link that seems disabled now.